### PR TITLE
ランディングページのデザインを改良 「取組の背景」項目を追加

### DIFF
--- a/components/atoms/Title.tsx
+++ b/components/atoms/Title.tsx
@@ -1,4 +1,4 @@
-import {ReactNode} from "react"
+import {ReactNode, useState} from "react"
 
 type Props = {
   children: ReactNode
@@ -8,15 +8,25 @@ type Props = {
  * タイトル
  */
 const Title = ({children} : Props) => {
+  const [hovering, setHovering] = useState<boolean>(false)
+
+  const onEnter = () => {
+    setHovering(true)
+  }
+
+  const onLeave = () => {
+    setHovering(false)
+  }
+
   return (
     <>
-      <div className="flex justify-center">
-        <img src="images/icon_logo.png" className="h-12 inline" />
+      <div className="flex justify-center" onMouseLeave={onLeave} onMouseEnter={onEnter}>
+        <img src="images/icon_logo.png" className={`h-12 inline ease-out duration-200 ${hovering ? ' -rotate-12' : 'transform-none'}`} />
         <div className="font-semibold text-4xl my-auto">
           {children}
         </div>
       </div>
-      <hr className="border-2 border-dashed mt-1 mx-4" />
+      <hr className="border-4 border-dashed mt-1 mx-4 border-[#019b4f]" />
     </>
   )
 }

--- a/components/landing/GekiatsuMapLink.tsx
+++ b/components/landing/GekiatsuMapLink.tsx
@@ -5,11 +5,11 @@ import Link from "next/link"
  */
 const GekiatsuMapLink = () => {
   return <>
-    <Link href="/" passHref>
-      <div className="text-2xl text-center">
-        <button className=" ease-in-out duration-100 hover:bg-[#CC7A00] rounded-full border-solid border-gray-200 hover:border-gray-50 border-4 px-6 py-3">激アツ！昆虫マップへ</button>
+      <div className="text-2xl text-center font-extrabold">
+        <Link href="/" passHref>
+          <button className="ease-out duration-100 bg-[#ea5315] hover:bg-[#ea642c] rounded-full border-solid border-gray-200 border-4 px-6 py-3">激アツ！昆虫マップへ</button>
+        </Link>
       </div>
-    </Link>
   </>
 }
 export default GekiatsuMapLink

--- a/components/landing/OpenDataReference.tsx
+++ b/components/landing/OpenDataReference.tsx
@@ -29,7 +29,7 @@ const OpenDataReference = () => {
     <div className="my-8 mx-4">
       <Title>オープンデータ</Title>
       <Description>
-        <div className="text-lg mb-2">激アツ！昆虫マップは、以下のオープンデータを使って作られました</div>
+        <div className="text-lg mb-2 font-semibold">激アツ！昆虫マップは、以下のオープンデータを使って作られました</div>
         <div className="grid gap-x-4 grid-cols-1 sm:grid-cols-2">
           {list.map(({name, url}) => (
             <div key={url} className="mb-3">

--- a/components/landing/ProjectContext.tsx
+++ b/components/landing/ProjectContext.tsx
@@ -1,0 +1,18 @@
+import Description from "../atoms/Description"
+import Title from "../atoms/Title"
+
+/**
+ * 取組の背景
+ */
+const ProjectContext = () => {
+  return <>
+    <div className="my-8 mx-4">
+      <Title>取組の背景</Title>
+      <Description>
+      </Description>
+    </div>
+  </>
+}
+
+export default ProjectContext
+

--- a/components/landing/Usage.tsx
+++ b/components/landing/Usage.tsx
@@ -7,21 +7,21 @@ import Title from "../atoms/Title"
 const Usage = () => {
   return <>
     <div className="my-8 mx-4">
-      <Title>使い方</Title>
+      <Title>つかいかた</Title>
       <Description>
         <div className="grid gap-x-4 grid-cols-1 sm:grid-cols-2">
           <div>
             <img className="mt-3 mx-auto" src="/images/gekiatsumap_1.jpg" />
             <div className="mt-2">
               昆虫がいそうなエリアに色がぬられているよ！<br />
-              色が濃くなればなるほど激アツ！！
+              色がこくなればなるほど激アツ！！
             </div>
           </div>
           <div>
             <img className="mt-3 mx-auto" src="/images/gekiatsumap_2.jpg" />
             <div className="mt-2">
               エリアを押すと激アツ度と、そのエリアの樹木が表示されるよ！<br />
-              昆虫のアイコンのある樹木はその昆虫の大好きな樹木！探してみよう！
+              昆虫のアイコンのある樹木はその昆虫の大好きな樹木！さがしてみよう！
             </div>
           </div>
         </div>

--- a/pages/landing/index.tsx
+++ b/pages/landing/index.tsx
@@ -4,6 +4,7 @@ import Introduction from '../../components/landing/Introduction'
 import Logo from '../../components/atoms/Logo'
 import Usage from '../../components/landing/Usage'
 import OpenDataReference from '../../components/landing/OpenDataReference'
+import ProjectContext from '../../components/landing/ProjectContext'
 
 /**
  * ランディングページ
@@ -15,6 +16,7 @@ export default function Landing() {
       <Introduction />
       <GekiatsuMapLink />
       <Usage />
+      <ProjectContext />
       <OpenDataReference />
     </div>
   )

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -15,7 +15,7 @@ body {
 }
 
 body {
-  color: rgb(255 255 255);
+  color: rgb(240 240 240);
   background: rgb(156, 94, 0);
 }
 


### PR DESCRIPTION
ランディングページのデザインを改良 「取組の背景」項目を追加した

<img width="1292" alt="image" src="https://user-images.githubusercontent.com/20750714/209916262-d78b4513-ae9d-49a1-baff-a209d22d849a.png">

取り組みの背景を追加。スライドに書かれていた取り組み背景を今後記述する
<img width="1292" alt="image" src="https://user-images.githubusercontent.com/20750714/209916283-58d4863f-1b8d-422d-bb1c-e1bb27a4ef48.png">
